### PR TITLE
[KGB-59] Creating Shift Gives it ACTIVE Status

### DIFF
--- a/practicum2425.Server/Controllers/ShiftController.cs
+++ b/practicum2425.Server/Controllers/ShiftController.cs
@@ -20,7 +20,7 @@ public class ShiftController : ControllerBase
     }
 
     [HttpPost("create")]
-    public async Task CreateShift([FromBody] ShiftDTO shiftDTO )
+    public async Task CreateShift([FromBody] ShiftDTO shiftDTO)
     {
         Shift shift = new Shift()
         {
@@ -29,7 +29,7 @@ public class ShiftController : ControllerBase
             Description = shiftDTO.Description,
             Location = shiftDTO.Location,
             RequestedEmployees = shiftDTO.RequestedEmployees,
-            Status = shiftDTO.Status,
+            Status = Shift.STATUS_ACTIVE,
         };
 
         await _shiftService.CreateShift(shift);

--- a/practicum2425.Server/DTOs/ShiftDTO.cs
+++ b/practicum2425.Server/DTOs/ShiftDTO.cs
@@ -1,18 +1,11 @@
-﻿namespace practicum2425.Server.DTOs
+﻿namespace practicum2425.Server.DTOs;
+
+public class ShiftDTO
 {
-    public class ShiftDTO
-    {
-
-        public string StartTime { get; set; } = null!;
-
-        public string EndTime { get; set; } = null!;
-
-        public string? Description { get; set; }
-
-        public string? Location { get; set; }
-
-        public int RequestedEmployees { get; set; }
-
-        public string Status { get; set; } = null!;
-    }
+    public string StartTime { get; set; }
+    public string EndTime { get; set; }
+    public string? Description { get; set; }
+    public string? Location { get; set; }
+    public int RequestedEmployees { get; set; }
+    public string Status { get; set; }
 }

--- a/practicum2425.client/Components/ShiftForm.tsx
+++ b/practicum2425.client/Components/ShiftForm.tsx
@@ -16,6 +16,7 @@ function ShiftForm() {
             Description: description,
             Location: location,
             RequestedEmployees: requestedEmployees,
+            Status: "ACTIVE"
         }
 
         Post(import.meta.env.VITE_API_URL + 'api/Shift/create', shift)

--- a/practicum2425.client/DataDTOInterfaces/ShiftDTOInterface.ts
+++ b/practicum2425.client/DataDTOInterfaces/ShiftDTOInterface.ts
@@ -4,4 +4,5 @@ export interface ShiftDTO {
     Description: string
     Location: string
     RequestedEmployees: number
+    Status: string
 }


### PR DESCRIPTION
Added "Status" back into the ShiftDTO on the FE. 

Depending on where we want the validation, the string contents will matter. 

Maybe we pass a string to the BE, then parse it to a DateTime? Then parse back into a string for the DB?